### PR TITLE
fix: compile and import with zig 0.14.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,7 @@
 .{
-    .name = "zbackoff",
-    .version = "0.1.2",
+    .name = .zbackoff,
+    .fingerprint = 0x617b2acc36544d3d,
+    .version = "0.1.3",
     .dependencies = .{},
     .paths = .{
         "build.zig",

--- a/src/zbackoff.zig
+++ b/src/zbackoff.zig
@@ -31,7 +31,7 @@ pub const Backoff = struct {
         const mu = @as(u64, @intFromFloat(mf));
 
         const seed = std.crypto.random.int(u64);
-        var prng = std.rand.DefaultPrng.init(seed);
+        var prng = std.Random.DefaultPrng.init(seed);
         const random = prng.random();
         const rval = 1 + random.uintAtMost(u64, mu);
         self.last = @min(self.max, rval);


### PR DESCRIPTION
This makes zbackoff compatible and importable with zig 0.14.0

Updates `build.zig.zon` to adhere to changes to the `name` field and add new `fingerprint` field. The fingerprint added is the suggested value by the compiler. 

Updates `zbackoff.zig` to reference to `std.Random` instead of the old `std.rand`